### PR TITLE
Performance of DiscoveryService.CalculateSourceLocationTrackingPositions

### DIFF
--- a/SpecFlow.VisualStudio.Package/ProjectSystem/NullVsIdeScope.cs
+++ b/SpecFlow.VisualStudio.Package/ProjectSystem/NullVsIdeScope.cs
@@ -193,9 +193,8 @@ namespace SpecFlow.VisualStudio.ProjectSystem
             DeveroomErrorListServices = null;
         }
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return null;
         }
 
         public IProjectScope[] GetProjectsWithFeatureFiles()

--- a/SpecFlow.VisualStudio.Package/ProjectSystem/VsIdeScopeLoader.cs
+++ b/SpecFlow.VisualStudio.Package/ProjectSystem/VsIdeScopeLoader.cs
@@ -92,7 +92,7 @@ namespace SpecFlow.VisualStudio.ProjectSystem
             }
         }
 
-        #region Delegaing members
+        #region Delegating members
 
         public bool IsSolutionLoaded => VsIdeScope.IsSolutionLoaded;
 
@@ -122,9 +122,9 @@ namespace SpecFlow.VisualStudio.ProjectSystem
             remove => VsIdeScope.WeakProjectOutputsUpdated -= value;
         }
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return VsIdeScope.CreatePersistentTrackingPosition(sourceLocation);
+            VsIdeScope.CalculateSourceLocationTrackingPositions(sourceLocations);
         }
 
         public bool GetTextBuffer(SourceLocation sourceLocation, out ITextBuffer textBuffer)

--- a/SpecFlow.VisualStudio.Package/VsUtils.cs
+++ b/SpecFlow.VisualStudio.Package/VsUtils.cs
@@ -57,10 +57,8 @@ namespace SpecFlow.VisualStudio
             }
         }
 
-        public static IWpfTextView GetWpfTextViewFromFilePath(string filePath, IServiceProvider serviceProvider)
+        public static IWpfTextView GetWpfTextViewFromFilePath(string filePath, IServiceProvider serviceProvider, IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
         {
-            var editorAdaptersFactoryService = ResolveMefDependency<IVsEditorAdaptersFactoryService>(serviceProvider);
-
             if (GetVsWindowFrame(filePath, serviceProvider, out var windowFrame))
             {
                 // Get the IVsTextView from the windowFrame.

--- a/SpecFlow.VisualStudio/Discovery/DiscoveryService.cs
+++ b/SpecFlow.VisualStudio/Discovery/DiscoveryService.cs
@@ -339,17 +339,8 @@ public class DiscoveryService : IDiscoveryService
 
     private void CalculateSourceLocationTrackingPositions(ProjectBindingRegistry bindingRegistry)
     {
-        int counter = 0;
-        foreach (var sourceLocation in bindingRegistry.StepDefinitions.Select(sd => sd.Implementation.SourceLocation)
-                     .Where(sl => sl != null))
-            if (sourceLocation.SourceLocationSpan == null)
-            {
-                counter++;
-                sourceLocation.SourceLocationSpan =
-                    _projectScope.IdeScope.CreatePersistentTrackingPosition(sourceLocation);
-            }
-
-        _logger.LogVerbose($"{counter} tracking positions calculated");
+        var sourceLocations = bindingRegistry.StepDefinitions.Select(sd => sd.Implementation.SourceLocation);
+        _projectScope.IdeScope.CalculateSourceLocationTrackingPositions(sourceLocations);
     }
 
     private void DisposeSourceLocationTrackingPositions(ProjectBindingRegistry bindingRegistry)

--- a/SpecFlow.VisualStudio/ProjectSystem/IIdeScope.cs
+++ b/SpecFlow.VisualStudio/ProjectSystem/IIdeScope.cs
@@ -24,7 +24,7 @@ namespace SpecFlow.VisualStudio.ProjectSystem
         event EventHandler<EventArgs> WeakProjectsBuilt;
         event EventHandler<EventArgs> WeakProjectOutputsUpdated;
 
-        IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation);
+        void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations);
         IProjectScope[] GetProjectsWithFeatureFiles();
 
         IDisposable CreateUndoContext(string undoLabel);

--- a/Tests/SpecFlow.VisualStudio.VsxStubs/ProjectSystem/StubIdeScope.cs
+++ b/Tests/SpecFlow.VisualStudio.VsxStubs/ProjectSystem/StubIdeScope.cs
@@ -52,9 +52,8 @@ namespace SpecFlow.VisualStudio.VsxStubs.ProjectSystem
         public event EventHandler<EventArgs> WeakProjectsBuilt;
         public event EventHandler<EventArgs> WeakProjectOutputsUpdated;
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return null;
         }
 
         public StubWpfTextView CreateTextView(TestText inputText, string newLine = null, IProjectScope projectScope = null, string contentType = VsContentTypes.FeatureFile, string filePath = null)


### PR DESCRIPTION
This is a port of https://github.com/specsolutions/deveroom-visualstudio/pull/73.

Profiling on a solution with a lot of Gherkin feature files shows that a significant amount of resources is taken in Deveroom/Specflow.VS when doing the repeated calls to `ResolveMefDependency` and `GetWpfTextViewFromFilePath` when calculating the tracking positions.

Here we reduce the number of calls to these methods:
- only call `ResolveMefDependency` once for each project being discovered
- group tracking positions by source file, so that we can call `GetWpfTextViewFromFilePath` once per source file only

After these changes, the resource usage for tracking position calculations goes down significantly.